### PR TITLE
Added PICO-TweenMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [pico8Grunt](https://github.com/TeamNoComplyGames/pico8Grunt) - A build system for pico8 games, using gruntjs.
 - [PICO-EC](https://github.com/JoebRogers/PICO-EC) - A tiny scene-entity-component library created for the PICO-8 fantasty console.
 - [PICO-Tween](https://github.com/JoebRogers/PICO-Tween) - A small library of tweening/easing functions for use in the PICO-8 fantasy console, inspired by Robert Penner's easing functions.
+- [PICO-TweenMachine](https://github.com/JoebRogers/PICO-Tween) - A small wrapper library for the PICO-8 fantasy console, meant as an extension to the PICO-Tween easing library.
 
 ## Text Editors Language Support
 


### PR DESCRIPTION
Added my new extension library, meant as a simplified wrapper engine to drive tweening code. Usable both alongside PICO-Tween or as a standalone tweening engine to drive custom Penner style tweens.