### PR TITLE
change PICO-8 plugin for VSCode to pico8-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
 
 ## Text Editors Language Support
 
-- Visual Studio Code: [vscode-pico8](https://github.com/nathanchere/vscode-pico8)
+- Visual Studio Code: [pico8-ls](https://github.com/japhib/pico8-ls) - PICO-8 Language Server, providing full language support for the PICO-8 dialect of Lua.
 - Atom: [language-pico8](https://atom.io/packages/language-pico8)
 - Sublime: [Sublime PICO-8](https://packagecontrol.io/packages/PICO-8) - PICO-8 plugin for the Sublime Text editor (color scheme, font, build system, code completion, snippets...).
 - Vim: [vim-pico8-syntax](https://github.com/justinj/vim-pico8-syntax)


### PR DESCRIPTION
This PR changes the PICO-8 plugin recommended for VSCode to [pico8-ls](https://github.com/japhib/pico8-ls) which has much better language support, a ton more features, and is in active development.

(The currently listed one, `vscode-pico8`, has 1 commit from 2016 and only provides syntax highlighting.)